### PR TITLE
fixes NPE in item pricer, and fixes 1.9.4/1.10.2 difference in bank.

### DIFF
--- a/java/universalcoins/util/UCItemPricer.java
+++ b/java/universalcoins/util/UCItemPricer.java
@@ -524,7 +524,8 @@ public class UCItemPricer {
 		for (Entry<ItemStack, ItemStack> recipe : recipes.entrySet()) {
 			ItemStack input = recipe.getKey();
 			ItemStack output = recipe.getValue();
-			if (ucPriceMap.get(input.getUnlocalizedName() + "." + input.getItemDamage()) != null) {
+			if (ucPriceMap.get(input.getUnlocalizedName() + "." + input.getItemDamage()) != null 
+			        && ucPriceMap.get(output.getUnlocalizedName() + "." + output.getItemDamage())!=null) {
 				int inputValue = ucPriceMap.get(input.getUnlocalizedName() + "." + input.getItemDamage());
 				int outputValue = ucPriceMap.get(output.getUnlocalizedName() + "." + output.getItemDamage());
 				if (inputValue != -1 && outputValue == -1) {

--- a/java/universalcoins/worldgen/ComponentVillageBank.java
+++ b/java/universalcoins/worldgen/ComponentVillageBank.java
@@ -3,6 +3,7 @@ package universalcoins.worldgen;
 import java.util.List;
 import java.util.Random;
 
+import net.minecraft.block.BlockDoor;
 import net.minecraft.block.BlockStairs;
 import net.minecraft.block.BlockTorch;
 import net.minecraft.block.material.Material;
@@ -106,7 +107,7 @@ public class ComponentVillageBank extends StructureVillagePieces.Village {
 				UniversalCoins.proxy.atm.getDefaultState().withProperty(BlockATM.FACING, EnumFacing.SOUTH), 2, 2, 4,
 				sbb);
 		// door
-		this.placeDoorCurrentPosition(world, sbb, random, 2, 1, 1, EnumFacing.NORTH);
+		this.placeDoor(world, sbb, random, 2, 1, 1, EnumFacing.NORTH);
 		// torches
 		this.setBlockState(world, Blocks.TORCH.getDefaultState().withProperty(BlockTorch.FACING, EnumFacing.NORTH), 1,
 				2, 2, boundingBox);
@@ -150,4 +151,13 @@ public class ComponentVillageBank extends StructureVillagePieces.Village {
 			}
 		}
 	}
+	
+    /**
+     * Places door on given position
+     */
+    protected void placeDoor(World worldIn, StructureBoundingBox boundingBoxIn, Random rand, int x, int y, int z, EnumFacing facing)
+    {
+        this.setBlockState(worldIn, Blocks.OAK_DOOR.getDefaultState().withProperty(BlockDoor.FACING, facing), x, y, z, boundingBoxIn);
+        this.setBlockState(worldIn, Blocks.OAK_DOOR.getDefaultState().withProperty(BlockDoor.FACING, facing).withProperty(BlockDoor.HALF, BlockDoor.EnumDoorHalf.UPPER), x, y + 1, z, boundingBoxIn);
+    }
 }


### PR DESCRIPTION
This fixes a possible case of NPEs occuring in the auto item pricer thing, where you can have null itemstacks in the output, before it just checked for them in the input.

This also changes how the doors are set for the bank, allowing it to work on both 1.9.4 and 1.10.2, when only being compiled for 1.9.4
